### PR TITLE
Parse numbers with comma separators

### DIFF
--- a/src/beancount.pest
+++ b/src/beancount.pest
@@ -17,7 +17,8 @@ date = { year ~ HYPHEN ~ month ~ HYPHEN ~ day }
 
 //// Number primitives
 num = @{ int ~ ("." ~ ASCII_DIGIT*)? }
-    int = { ("+" | "-")? ~ ASCII_DIGIT+ }
+    int = { ("+" | "-")? ~ ( ASCII_DIGIT{4,} | separated_int ) }
+    separated_int = { ASCII_DIGIT{1,3} ~ ( "," ~ ASCII_DIGIT{3} )* }
 operation = _{ add | subtract | multiply | divide }
     add      = { "+" }
     subtract = { "-" }


### PR DESCRIPTION
Allow comma separators in number as in beancount, e.g. `1,234.56`, but not `12,34.56`.

This doesn't seem to be documented very well. The only reference I could find was the `render_commas` option in the Options Reference: 
https://docs.google.com/document/d/1_-T_BvDtUjj9M7liZMNSkrL8pgC60TGMBlYCiV1e4ZM/edit