### PR TITLE
Fix compilation error, stop using deprecated function

### DIFF
--- a/beancount-parser/src/lib.rs
+++ b/beancount-parser/src/lib.rs
@@ -458,7 +458,7 @@ fn term<'i>(pair: Pair<'i, Rule>) -> Decimal {
         _ => unimplemented!(),
     };
     if let Some("-") = prefix {
-        num_expr.set_sign(!num_expr.is_sign_positive());
+        num_expr.set_sign_positive(!num_expr.is_sign_positive());
     }
     num_expr
 }

--- a/beancount-parser/src/lib.rs
+++ b/beancount-parser/src/lib.rs
@@ -618,7 +618,7 @@ fn compound_amount<'i>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core as bc;
+    use crate::bc;
     use indoc::indoc;
     use pest::Parser;
 


### PR DESCRIPTION
Looks like #24 broke compilation for `#[cfg(test)]`.  I also changed usage of the deprecated `set_sign` to `set_sign_positive`.

See build failure: https://travis-ci.org/github/twilco/beancount/builds/682321633