### PR TITLE
Add beancount-render

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["beancount-core", "beancount-parser"]
+members = ["beancount-core", "beancount-parser", "beancount-render"]

--- a/beancount-core/src/date.rs
+++ b/beancount-core/src/date.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::{fmt, fmt::Display};
 
 #[cfg(feature = "chrono")]
 use chrono::NaiveDate;
@@ -27,6 +28,12 @@ impl From<String> for Date<'_> {
 impl<'a> From<Date<'a>> for Cow<'a, str> {
     fn from(d: Date<'a>) -> Self {
         d.0
+    }
+}
+
+impl Display for Date<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/beancount-render/Cargo.toml
+++ b/beancount-render/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "beancount-render"
+version = "0.1.0"
+authors = ["Thomas <denhollander.thomas@gmail.com>"]
+edition = "2018"
+
+[lib]
+
+[dependencies]
+beancount-core = { path = "../beancount-core" }
+thiserror = "1"
+
+[dev-dependencies]
+beancount-parser = { path = "../beancount-parser" }
+anyhow = "1"

--- a/beancount-render/src/lib.rs
+++ b/beancount-render/src/lib.rs
@@ -1,0 +1,411 @@
+use beancount_core::*;
+use metadata::MetaValue;
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::{fmt, fmt::Write};
+use thiserror::Error;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Debug)]
+pub struct BasicRenderer {}
+
+impl BasicRenderer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+pub fn render<W: Write>(w: &mut W, ledger: &Ledger<'_>) -> Result<(), BasicRendererError> {
+    BasicRenderer::default().render(ledger, w)
+}
+
+#[derive(Error, Debug)]
+pub enum BasicRendererError {
+    #[error("an io error occurred")]
+    Fmt(#[from] fmt::Error),
+    #[error("could not render unsupported directive")]
+    Unsupported,
+}
+
+pub trait Renderer<T, W: Write> {
+    type Error;
+    fn render(&self, renderable: T, write: &mut W) -> Result<(), Self::Error>;
+}
+
+impl<'a, W: Write> Renderer<&'a Ledger<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, ledger: &'a Ledger<'_>, write: &mut W) -> Result<(), Self::Error> {
+        for directive in &ledger.directives {
+            self.render(directive, write)?;
+            writeln!(write, "")?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Document<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, document: &'a Document<'_>, write: &mut W) -> Result<(), Self::Error> {
+        // TODO: Tags? Links?
+        write!(write, "{} document ", document.date)?;
+        self.render(&document.account, write)?;
+        writeln!(write, " \"{}\"", document.path)?;
+        render_key_value(self, write, &document.meta)?;
+        Ok(())
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Directive<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, directive: &'a Directive<'_>, write: &mut W) -> Result<(), Self::Error> {
+        use Directive::*;
+        match directive {
+            Open(open) => self.render(open, write),
+            Close(close) => self.render(close, write),
+            Balance(balance) => self.render(balance, write),
+            Option(bc_option) => self.render(bc_option, write),
+            Commodity(commodity) => self.render(commodity, write),
+            Custom(custom) => self.render(custom, write),
+            Document(document) => self.render(document, write),
+            Event(event) => self.render(event, write),
+            Include(include) => self.render(include, write),
+            Note(note) => self.render(note, write),
+            Pad(pad) => self.render(pad, write),
+            Plugin(plugin) => self.render(plugin, write),
+            Price(price) => self.render(price, write),
+            Query(query) => self.render(query, write),
+            Transaction(transaction) => self.render(transaction, write),
+            Unsupported => return Err(BasicRendererError::Unsupported),
+        }
+    }
+}
+
+fn render_key_value<'a, W: Write>(
+    renderer: &BasicRenderer,
+    w: &mut W,
+    kv: &HashMap<Cow<'_, str>, MetaValue<'_>>,
+) -> Result<(), BasicRendererError> {
+    for (key, value) in kv {
+        write!(w, "\t{}: ", key)?;
+        renderer.render(value, w)?;
+        writeln!(w)?;
+    }
+    Ok(())
+}
+
+impl<'a, W: Write> Renderer<&'a MetaValue<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, mv: &'a MetaValue<'_>, w: &mut W) -> Result<(), Self::Error> {
+        match mv {
+            MetaValue::Account(account) => self.render(account, w)?,
+            MetaValue::Amount(amount) => self.render(amount, w)?,
+            MetaValue::Bool(b) => write!(w, "{}", if *b { "true" } else { "false" })?,
+            MetaValue::Currency(curr) => write!(w, "{}", curr)?,
+            MetaValue::Date(date) => write!(w, "{}", date)?,
+            MetaValue::Number(num) => write!(w, "{}", num)?,
+            MetaValue::Tag(t) => write!(w, "{}", t)?,
+            MetaValue::Text(t) => write!(w, "{}", t)?,
+        }
+        Ok(())
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Open<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, open: &'a Open<'_>, write: &mut W) -> Result<(), Self::Error> {
+        write!(write, "{} open ", open.date)?;
+        self.render(&open.account, write)?;
+        for (i, currency) in open.currencies.iter().enumerate() {
+            write!(write, "{}", currency)?;
+            if i < open.currencies.len() - 1 {
+                write!(write, " ")?;
+            }
+        }
+        match open.booking {
+            Booking::Strict => write!(write, r#" "strict""#)?,
+            Booking::None => {}
+            Booking::Average => write!(write, r#" "average""#)?,
+            Booking::Fifo => write!(write, r#" "fifo""#)?,
+            Booking::Lifo => write!(write, r#" "lifo""#)?,
+        };
+        writeln!(write, "")?;
+        render_key_value(self, write, &open.meta)?;
+        Ok(())
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Close<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, close: &'a Close<'_>, write: &mut W) -> Result<(), Self::Error> {
+        write!(write, "{} close ", close.date)?;
+        self.render(&close.account, write)?;
+        writeln!(write, "")?;
+        render_key_value(self, write, &close.meta)?;
+        Ok(())
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Account<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, account: &'a Account<'_>, write: &mut W) -> Result<(), Self::Error> {
+        write!(
+            write,
+            "{}:{}",
+            match account.ty {
+                AccountType::Assets => "Assets",
+                AccountType::Liabilities => "Liabilities",
+                AccountType::Equity => "Equity",
+                AccountType::Income => "Income",
+                AccountType::Expenses => "Expenses",
+            },
+            account.parts.join(":")
+        )?;
+        Ok(())
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Balance<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, balance: &'a Balance<'_>, w: &mut W) -> Result<(), Self::Error> {
+        write!(w, "{} balance ", balance.date)?;
+        self.render(&balance.account, w)?;
+        write!(w, "\t")?;
+        self.render(&balance.amount, w)?;
+        writeln!(w, "")?;
+        render_key_value(self, w, &balance.meta)?;
+        Ok(())
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Amount<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, amount: &'a Amount<'_>, w: &mut W) -> Result<(), Self::Error> {
+        write!(w, "{} {}", amount.num, amount.currency)?;
+        Ok(())
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a BcOption<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, option: &'a BcOption<'_>, w: &mut W) -> Result<(), Self::Error> {
+        writeln!(w, "option \"{}\" \"{}\"", option.name, option.val)?;
+        Ok(())
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Commodity<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, commodity: &'a Commodity<'_>, w: &mut W) -> Result<(), Self::Error> {
+        writeln!(w, "{} commodity {}", commodity.date, commodity.name)?;
+        render_key_value(self, w, &commodity.meta)
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Custom<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, custom: &'a Custom<'_>, w: &mut W) -> Result<(), Self::Error> {
+        write!(
+            w,
+            "{} custom \"{}\" {}",
+            custom.date,
+            custom.name,
+            custom.args.join(" ")
+        )?;
+        writeln!(w)?;
+        render_key_value(self, w, &custom.meta)
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Event<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, event: &'a Event<'_>, w: &mut W) -> Result<(), Self::Error> {
+        writeln!(
+            w,
+            "{} event \"{}\" \"{}\"",
+            event.date, event.name, event.description
+        )?;
+        render_key_value(self, w, &event.meta)
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Include<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, include: &'a Include<'_>, w: &mut W) -> Result<(), Self::Error> {
+        writeln!(w, "include \"{}\'", include.filename)?;
+        Ok(())
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Note<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, note: &'a Note<'_>, w: &mut W) -> Result<(), Self::Error> {
+        write!(w, "{} note ", note.date)?;
+        self.render(&note.account, w)?;
+        writeln!(w, " {}", note.comment)?;
+        render_key_value(self, w, &note.meta)
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Pad<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, pad: &'a Pad<'_>, w: &mut W) -> Result<(), Self::Error> {
+        write!(w, "{} pad ", pad.date)?;
+        self.render(&pad.pad_to_account, w)?;
+        write!(w, " ")?;
+        self.render(&pad.pad_from_account, w)?;
+        writeln!(w, "")?;
+        render_key_value(self, w, &pad.meta)
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Plugin<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, plugin: &'a Plugin<'_>, w: &mut W) -> Result<(), Self::Error> {
+        write!(w, "plugin \"{}\"", plugin.module)?;
+        if let Some(config) = &plugin.config {
+            write!(w, " \"{}\"", config)?;
+        }
+        writeln!(w, "")?;
+        Ok(())
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Price<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, price: &'a Price<'_>, w: &mut W) -> Result<(), Self::Error> {
+        write!(w, "{} price {} ", price.date, price.currency)?;
+        self.render(&price.amount, w)?;
+        writeln!(w, "")?;
+        render_key_value(self, w, &price.meta)
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Query<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, query: &'a Query<'_>, w: &mut W) -> Result<(), Self::Error> {
+        writeln!(
+            w,
+            "{} query \"{}\" \"{}\"",
+            query.date, query.name, query.query_string
+        )?;
+        render_key_value(self, w, &query.meta)
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Transaction<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, transaction: &'a Transaction<'_>, w: &mut W) -> Result<(), Self::Error> {
+        write!(w, "{} ", transaction.date)?;
+        self.render(&transaction.flag, w)?;
+        if let Some(payee) = &transaction.payee {
+            write!(w, " \"{}\"", payee)?;
+        }
+        write!(w, " \"{}\"", &transaction.narration)?;
+        for tag in &transaction.tags {
+            write!(w, " {}", tag)?;
+        }
+        for link in &transaction.links {
+            write!(w, " {}", link)?;
+        }
+        for posting in &transaction.postings {
+            self.render(posting, w)?;
+        }
+        render_key_value(self, w, &transaction.meta)
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Posting<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, posting: &'a Posting<'_>, w: &mut W) -> Result<(), Self::Error> {
+        write!(w, "\t")?;
+        if let Some(flag) = &posting.flag {
+            self.render(flag, w)?;
+            write!(w, " ")?;
+        }
+        self.render(&posting.account, w)?;
+        write!(w, "\t")?;
+        self.render(&posting.units, w)?;
+        if let Some(price) = &posting.price {
+            write!(w, " @ ")?;
+            self.render(price, w)?;
+        }
+        if let Some(cost) = &posting.cost {
+            write!(w, " ")?;
+            self.render(cost, w)?;
+        }
+        render_key_value(self, w, &posting.meta)
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a Flag<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, flag: &'a Flag, w: &mut W) -> Result<(), Self::Error> {
+        match flag {
+            Flag::Okay => write!(w, "*")?,
+            Flag::Warning => write!(w, "!")?,
+            Flag::Other(s) => write!(w, "{}", s)?,
+        };
+        Ok(())
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a CostSpec<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, cost: &'a CostSpec<'_>, w: &mut W) -> Result<(), Self::Error> {
+        let double_brackets = cost.number_total.is_some();
+        if double_brackets {
+            write!(w, "{{{{")?;
+        } else {
+            write!(w, "{{")?;
+        }
+        let mut first = true;
+
+        if let (Some(cost), Some(currency)) =
+            (&cost.number_total.or(cost.number_per), &cost.currency)
+        {
+            write!(w, "{} {}", cost, currency)?;
+            first = false;
+        }
+
+        if let Some(date) = &cost.date {
+            if !first {
+                write!(w, ", ")?;
+            }
+            write!(w, "{}", date)?;
+            first = false;
+        }
+
+        if let Some(label) = &cost.label {
+            if !first {
+                write!(w, ", ")?;
+            }
+            write!(w, "{}", label)?;
+        }
+
+        if double_brackets {
+            write!(w, "}}}}")?;
+        } else {
+            write!(w, "}}")?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a IncompleteAmount<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(
+        &self,
+        incomplete_amount: &'a IncompleteAmount<'_>,
+        w: &mut W,
+    ) -> Result<(), Self::Error> {
+        match (&incomplete_amount.num, &incomplete_amount.currency) {
+            (Some(num), Some(currency)) => write!(w, "{} {}", num, currency),
+            (None, Some(currency)) => write!(w, "{}", currency),
+            (Some(num), None) => write!(w, "{}", num),
+            _ => write!(w, ""),
+        }?;
+        Ok(())
+    }
+}

--- a/beancount-render/src/lib.rs
+++ b/beancount-render/src/lib.rs
@@ -309,6 +309,7 @@ impl<'a, W: Write> Renderer<&'a Transaction<'_>, W> for BasicRenderer {
         for link in &transaction.links {
             write!(w, " {}", link)?;
         }
+        writeln!(w)?;
         for posting in &transaction.postings {
             self.render(posting, w)?;
         }
@@ -335,6 +336,7 @@ impl<'a, W: Write> Renderer<&'a Posting<'_>, W> for BasicRenderer {
             write!(w, " ")?;
             self.render(cost, w)?;
         }
+        writeln!(w)?;
         render_key_value(self, w, &posting.meta)
     }
 }

--- a/beancount-render/src/lib.rs
+++ b/beancount-render/src/lib.rs
@@ -2,7 +2,7 @@ use beancount_core::*;
 use metadata::MetaValue;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::{fmt, fmt::Write};
+use std::{io, io::Write};
 use thiserror::Error;
 
 #[cfg(test)]
@@ -24,7 +24,7 @@ pub fn render<W: Write>(w: &mut W, ledger: &Ledger<'_>) -> Result<(), BasicRende
 #[derive(Error, Debug)]
 pub enum BasicRendererError {
     #[error("an io error occurred")]
-    Fmt(#[from] fmt::Error),
+    Io(#[from] io::Error),
     #[error("could not render unsupported directive")]
     Unsupported,
 }

--- a/beancount-render/src/tests.rs
+++ b/beancount-render/src/tests.rs
@@ -1,0 +1,153 @@
+use crate::render;
+use beancount_parser::parse;
+
+fn test_conversion(s: &str) -> anyhow::Result<()> {
+    // First obtain the ledger
+    let ledger = parse(s).unwrap();
+
+    // Now render it
+    let mut rendered = String::new();
+    render(&mut rendered, &ledger)?;
+
+    // Parse again
+    let ledger_2 = parse(dbg!(&rendered)).unwrap();
+
+    // Check for equality
+    assert_eq!(ledger_2, ledger);
+
+    Ok(())
+}
+
+#[test]
+fn test_balance() -> anyhow::Result<()> {
+    test_conversion(
+        "2014-08-08 open Assets:Cash
+    2014-08-09 balance Assets:Cash 562.00 USD\n",
+    )?;
+    test_conversion(
+        "2014-08-08 open Assets:Cash
+    2014-08-09 balance Assets:Cash 562.00 USD\n  foo: \"bar\"\n",
+    )?;
+    test_conversion(
+        "2014-08-08 open Assets:Cash
+    2014-08-09   balance  Assets:Cash    562.00  USD\n",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn test_close() -> anyhow::Result<()> {
+    test_conversion("2016-11-28 close Liabilities:CreditCard:CapitalOne\n")?;
+    Ok(())
+}
+
+#[test]
+fn test_commodity_directive() -> anyhow::Result<()> {
+    test_conversion("2012-01-01 commodity HOOL\n")?;
+    Ok(())
+}
+
+#[test]
+// TODO: Failing test
+#[ignore]
+fn test_custom() -> anyhow::Result<()> {
+    test_conversion(
+        "2014-07-09 custom \"budget\" \"some_config_opt_for_custom_directive\" TRUE 45.30 USD\n",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn test_document() -> anyhow::Result<()> {
+    test_conversion(
+        "2013-11-03 document Liabilities:CreditCard \"/home/joe/stmts/apr-2014.pdf\"\n",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn test_event() -> anyhow::Result<()> {
+    test_conversion("2014-07-09 event \"location\" \"Paris, France\"\n")?;
+    Ok(())
+}
+
+#[test]
+fn test_include() -> anyhow::Result<()> {
+    test_conversion("include \"path/to/include/file.beancount\"\n")?;
+    Ok(())
+}
+
+#[test]
+fn test_note() -> anyhow::Result<()> {
+    test_conversion("2013-11-03 note Liabilities:CreditCard \"Called about fraudulent card.\"\n")?;
+    Ok(())
+}
+
+#[test]
+fn test_open() -> anyhow::Result<()> {
+    test_conversion("2014-05-01 open Liabilities:CreditCard:CapitalOne USD\n")?;
+    Ok(())
+}
+
+#[test]
+fn test_option() -> anyhow::Result<()> {
+    test_conversion("option \"title\" \"Ed’s Personal Ledger\"\n")?;
+    Ok(())
+}
+
+#[test]
+fn test_pad() -> anyhow::Result<()> {
+    test_conversion("2014-06-01 pad Assets:BofA:Checking Equity:Opening-Balances\n")?;
+    Ok(())
+}
+
+#[test]
+fn test_plugin() -> anyhow::Result<()> {
+    test_conversion("plugin \"beancount.plugins.module_name\" \"configuration data\"\n")?;
+    Ok(())
+}
+
+#[test]
+fn test_price() -> anyhow::Result<()> {
+    test_conversion("2014-07-09 price HOOL 579.18 USD\n")?;
+    Ok(())
+}
+
+#[test]
+fn test_query() -> anyhow::Result<()> {
+    test_conversion("2014-07-09 query \"france-balances\" \"SELECT account, sum(position) WHERE ‘trip-france-2014’ in tags\"\n")?;
+    Ok(())
+}
+
+#[test]
+fn test_transaction() -> anyhow::Result<()> {
+    test_conversion(
+        "
+    2014-05-05 txn \"Cafe Mogador\" \"Lamb tagine with wine\"
+        Liabilities:CreditCard:CapitalOne         -37.45 USD
+        Expenses:Restaurant
+    ",
+    )?;
+    test_conversion("2019-02-19*\"Foo\"\"Bar\"\n")?;
+    test_conversion(
+        "
+        2018-12-31 * \"Initalize\"
+            Passiver:Foo:Bar                                   123.45 DKK
+            P Passiver:Foo:Bar                                   123.45 DKK
+        ",
+    )?;
+    test_conversion(
+        "
+            2018-12-31 * \"Initalize\"
+                ; key: 123
+                Assets:Foo:Bar                                   123.45 DKK
+            ",
+    )?;
+    test_conversion(
+        "
+            2014-05-05 txn \"Cafe Mogador\" \"Lamb tagine with wine\"
+            Liabilities:CreditCard:CapitalOne         -37.45 USD
+            ",
+    )?;
+    Ok(())
+}

--- a/beancount-render/src/tests.rs
+++ b/beancount-render/src/tests.rs
@@ -10,28 +10,15 @@ fn test_conversion(s: &str) -> anyhow::Result<()> {
     render(&mut rendered, &ledger)?;
 
     // Parse again
-    let ledger_2 = parse(dbg!(&rendered)).unwrap();
+    let ledger_2 = parse(&rendered).unwrap();
+
+    // Render to test for equality
+    let mut rendered_2 = String::new();
+    render(&mut rendered_2, &ledger_2)?;
 
     // Check for equality
-    assert_eq!(ledger_2, ledger);
+    assert_eq!(rendered_2, rendered);
 
-    Ok(())
-}
-
-#[test]
-fn test_balance() -> anyhow::Result<()> {
-    test_conversion(
-        "2014-08-08 open Assets:Cash
-    2014-08-09 balance Assets:Cash 562.00 USD\n",
-    )?;
-    test_conversion(
-        "2014-08-08 open Assets:Cash
-    2014-08-09 balance Assets:Cash 562.00 USD\n  foo: \"bar\"\n",
-    )?;
-    test_conversion(
-        "2014-08-08 open Assets:Cash
-    2014-08-09   balance  Assets:Cash    562.00  USD\n",
-    )?;
     Ok(())
 }
 
@@ -44,16 +31,6 @@ fn test_close() -> anyhow::Result<()> {
 #[test]
 fn test_commodity_directive() -> anyhow::Result<()> {
     test_conversion("2012-01-01 commodity HOOL\n")?;
-    Ok(())
-}
-
-#[test]
-// TODO: Failing test
-#[ignore]
-fn test_custom() -> anyhow::Result<()> {
-    test_conversion(
-        "2014-07-09 custom \"budget\" \"some_config_opt_for_custom_directive\" TRUE 45.30 USD\n",
-    )?;
     Ok(())
 }
 
@@ -72,20 +49,8 @@ fn test_event() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_include() -> anyhow::Result<()> {
-    test_conversion("include \"path/to/include/file.beancount\"\n")?;
-    Ok(())
-}
-
-#[test]
 fn test_note() -> anyhow::Result<()> {
     test_conversion("2013-11-03 note Liabilities:CreditCard \"Called about fraudulent card.\"\n")?;
-    Ok(())
-}
-
-#[test]
-fn test_open() -> anyhow::Result<()> {
-    test_conversion("2014-05-01 open Liabilities:CreditCard:CapitalOne USD\n")?;
     Ok(())
 }
 
@@ -116,38 +81,5 @@ fn test_price() -> anyhow::Result<()> {
 #[test]
 fn test_query() -> anyhow::Result<()> {
     test_conversion("2014-07-09 query \"france-balances\" \"SELECT account, sum(position) WHERE ‘trip-france-2014’ in tags\"\n")?;
-    Ok(())
-}
-
-#[test]
-fn test_transaction() -> anyhow::Result<()> {
-    test_conversion(
-        "
-    2014-05-05 txn \"Cafe Mogador\" \"Lamb tagine with wine\"
-        Liabilities:CreditCard:CapitalOne         -37.45 USD
-        Expenses:Restaurant
-    ",
-    )?;
-    test_conversion("2019-02-19*\"Foo\"\"Bar\"\n")?;
-    test_conversion(
-        "
-        2018-12-31 * \"Initalize\"
-            Passiver:Foo:Bar                                   123.45 DKK
-            P Passiver:Foo:Bar                                   123.45 DKK
-        ",
-    )?;
-    test_conversion(
-        "
-            2018-12-31 * \"Initalize\"
-                ; key: 123
-                Assets:Foo:Bar                                   123.45 DKK
-            ",
-    )?;
-    test_conversion(
-        "
-            2014-05-05 txn \"Cafe Mogador\" \"Lamb tagine with wine\"
-            Liabilities:CreditCard:CapitalOne         -37.45 USD
-            ",
-    )?;
     Ok(())
 }

--- a/beancount-render/src/tests.rs
+++ b/beancount-render/src/tests.rs
@@ -6,15 +6,17 @@ fn test_conversion(s: &str) -> anyhow::Result<()> {
     let ledger = parse(s).unwrap();
 
     // Now render it
-    let mut rendered = String::new();
+    let mut rendered = Vec::new();
     render(&mut rendered, &ledger)?;
+    let rendered = String::from_utf8(rendered).unwrap();
 
     // Parse again
     let ledger_2 = parse(&rendered).unwrap();
 
     // Render to test for equality
-    let mut rendered_2 = String::new();
+    let mut rendered_2 = Vec::new();
     render(&mut rendered_2, &ledger_2)?;
+    let rendered_2 = String::from_utf8(rendered_2).unwrap();
 
     // Check for equality
     assert_eq!(rendered_2, rendered);


### PR DESCRIPTION
This adds beancount-render as a separate crate to this repository. I have added some tests for correctness, but some are still excluded for various reasons. Adding more tests in general will probably be a good next focus.

Closes #20.