### PR TITLE
Pushtag and poptag

### DIFF
--- a/beancount-parser/src/beancount.pest
+++ b/beancount-parser/src/beancount.pest
@@ -104,6 +104,12 @@ price = { date ~ "price" ~ commodity ~ amount ~ eol_kv_list }
 //   SELECT account, sum(position) WHERE ‘trip-france-2014’ in tags"
 query = { date ~ "query" ~ quoted_str ~ quoted_str ~ eol_kv_list }
 
+// pushtag #trip-to-peru
+pushtag = { "pushtag" ~ tag ~ eol }
+
+// poptag #trip-to-peru
+poptag = { "poptag" ~ tag ~ eol }
+
 //// Transaction directive
 
 // 2014-05-05 txn "Cafe Mogador" "Lamb tagine with wine"
@@ -163,4 +169,4 @@ compound_amount = {
     num_expr ~ commodity?
 }
 
-file = { SOI ~ (org_mode_title | option | plugin | custom | document | commodity_directive | balance | event | include | note | open | close | pad | price | query | transaction | eol)* ~ EOI}
+file = { SOI ~ (org_mode_title | option | plugin | custom | document | commodity_directive | balance | event | include | note | open | close | pad | price | query | transaction | pushtag | poptag | eol)* ~ EOI}

--- a/beancount-parser/src/error.rs
+++ b/beancount-parser/src/error.rs
@@ -164,6 +164,8 @@ impl From<pest::error::Error<Rule>> for ParseError {
                 Rule::plugin => "plugin directive",
                 Rule::price => "price directive",
                 Rule::query => "query directive",
+                Rule::pushtag => "pushtag",
+                Rule::poptag => "poptag",
                 Rule::transaction => "transaction directive",
                 Rule::txn_flag => "transaction flag",
                 Rule::flag_okay => "'txn' or '*'",


### PR DESCRIPTION
Added code to support poptag and pushtag directives.
ParseState maintains a HashMap ("stack") of tags. When a pushtag is encountered, the tag is added to the stack (+1 count). When a poptag is encountered the tag is -1 counted, and removed if count become zero. When a transaction is encountered, all the tags currently stored in the "stack" are added to the transactions tag set. An error is generated if a poptag is encountered for a tag that is not in the "stack", and an error is generated if there are still any tags left in the "stack" when the end of input is reached.