### PR TITLE
Add parsing and rendering of total prices

### DIFF
--- a/beancount-core/src/lib.rs
+++ b/beancount-core/src/lib.rs
@@ -10,6 +10,7 @@ pub use directives::*;
 pub use flags::Flag;
 pub use position::CostSpec;
 pub use posting::Posting;
+pub use posting::PriceSpec;
 
 pub mod account;
 pub mod account_types;

--- a/beancount-core/src/posting.rs
+++ b/beancount-core/src/posting.rs
@@ -41,11 +41,17 @@ pub struct Posting<'a> {
 
     /// The price of this posting.
     #[builder(default)]
-    pub price: Option<IncompleteAmount<'a>>,
+    pub price: Option<PriceSpec<'a>>,
 
     #[builder(default)]
     pub flag: Option<Flag<'a>>,
 
     #[builder(default)]
     pub meta: Meta<'a>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum PriceSpec<'a> {
+    PerUnit(IncompleteAmount<'a>),
+    Total(IncompleteAmount<'a>),
 }

--- a/beancount-render/src/lib.rs
+++ b/beancount-render/src/lib.rs
@@ -324,7 +324,7 @@ impl<'a, W: Write> Renderer<&'a Posting<'_>, W> for BasicRenderer {
             self.render(cost, w)?;
         }
         if let Some(price) = &posting.price {
-            write!(w, " @ ")?;
+            write!(w, " ")?;
             self.render(price, w)?;
         }
         writeln!(w)?;
@@ -371,6 +371,23 @@ impl<'a, W: Write> Renderer<&'a CostSpec<'_>, W> for BasicRenderer {
             write!(w, "}}")?;
         }
         Ok(())
+    }
+}
+
+impl<'a, W: Write> Renderer<&'a PriceSpec<'_>, W> for BasicRenderer {
+    type Error = BasicRendererError;
+    fn render(&self, price: &'a PriceSpec<'_>, w: &mut W) -> Result<(), Self::Error> {
+        let amount = match price {
+            PriceSpec::PerUnit(amount) => {
+                write!(w, "@ ")?;
+                amount
+            }
+            PriceSpec::Total(amount) => {
+                write!(w, "@@ ")?;
+                amount
+            }
+        };
+        self.render(amount, w)
     }
 }
 


### PR DESCRIPTION
Beancount has
- the `@` syntax for per-unit prices
- the `@@` syntax for total prices

Previously
- the renderer only supported per-unit prices, but not total prices
- the parser supported total prices, but immediately converted them to per-unit prices

Now, with this PR, total prices are fully supported and represented in the IR.